### PR TITLE
Accept globs for css parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,3 @@ Metalsmith()
 
 Note that if you'd like to overwrite the original CSS file, set the `output`
 name to match the `css` filename.
-
----
-
-## Limitations
-
-- The plugin currently only accepts one CSS file as the input, such as a
-compiled Sass stylesheet.
-- PurifyCSS does not seem to prune HTML tags (`h1`, `p`, etc.), but works
-great for CSS selectors such as classes and IDs.

--- a/__tests__/fixtures/src/index.html
+++ b/__tests__/fixtures/src/index.html
@@ -12,5 +12,9 @@
     <p class="className">Testing with a classname</p>
 
     <p class="unusual(class)">This should remain</p>
+
+    <div class="multipleCSSfiles">This should remain if using style2.css</div>
+
+    <span>This should remain if using style2.css</span>
   </body>
 </html>

--- a/__tests__/fixtures/src/style3.css
+++ b/__tests__/fixtures/src/style3.css
@@ -1,0 +1,3 @@
+span {
+  margin: 10px;
+}

--- a/__tests__/fixtures/src/styles2.css
+++ b/__tests__/fixtures/src/styles2.css
@@ -1,0 +1,3 @@
+.multipleCSSfiles {
+  border: 1px solid hotpink;
+}

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -74,3 +74,28 @@ test('whitelist option is respected', () => {
     expect(files['styles-cleaned.css'].contents.toString()).toContain('#whitelisted');
   })
 });
+
+test('an array of stylesheets is accepted', () => {
+  const options = {
+    content: ['*.html', '*.js'],
+    css: ['styles.css', 'styles2.css'],
+    output: 'styles-cleaned.css',
+  };
+
+  return build(options).then((files) => {
+    expect(files['styles-cleaned.css'].contents.toString()).toContain('.multipleCSSfiles');
+  })
+});
+
+
+test('a glob is accepted for CSS parameter', () => {
+  const options = {
+    content: ['*.html', '*.js'],
+    css: ['*.css'],
+    output: 'styles-cleaned.css',
+  };
+
+  return build(options).then((files) => {
+    expect(files['styles-cleaned.css'].contents.toString()).toContain('span');
+  })
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,24 +9,26 @@ const plugin = (options) => {
   delete options.output;
 
   return function(files, metalsmith, done) {
-    // Stringify HTML & other structural markup
     const fileNames = Object.keys(files);
-    const filteredFiles = [...content].reduce((filteredFiles, filename) => {
-      return filteredFiles.concat(
-        minimatch.match(fileNames, filename, { matchBase: true })
-      );
-    }, []);
 
-    const structure = [...filteredFiles].reduce((structure, filename) => {
-      structure.push(files[filename].contents.toString());
-      return structure;
-    }, []).toString();
+    const filterFiles = (targetFiles) => {
+      return [...targetFiles].reduce((matchedFiles, filename) => {
+        return matchedFiles.concat(
+          minimatch.match(fileNames, filename, { matchBase: true })
+        );
+      }, []);
+    };
 
-    // Stringify CSS
-    const styles = [...css].reduce((styles, filename) => {
-      styles.push(files[filename].contents.toString());
-      return styles;
-    }, []).toString();
+    const concatContents = (targetFiles) => {
+      return [...targetFiles].reduce((contents, filename) => {
+        contents.push(files[filename].contents.toString());
+        return contents;
+      }, []).toString();
+    }
+
+    // Stringify matched HTML & CSS file contents
+    const structure = concatContents(filterFiles(content));
+    const styles = concatContents(filterFiles(css));
 
     // Pass code and CSS to Purify
     purifyCSS(structure, styles, options, (results) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-purifycss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PurifyCSS plugin for Metalsmith static site generator",
   "main": "lib/index.js",
   "repository": "https://github.com/alex-ketch/metalsmith-purifycss",
@@ -23,6 +23,8 @@
     ]
   },
   "jest": {
-    "testMatch": ["**/__tests__/index.test.js"]
+    "testMatch": [
+      "**/__tests__/index.test.js"
+    ]
   }
 }


### PR DESCRIPTION
Adds functionality to specify globs as well as multiple CSS filenames in an array for the `css` option parameter.

E.g.
``` js
...
.use(purifyCSS({
  content: ['*.html', '*.js'],
  css: ['*.css'],
  output: 'styles-purified.css',
}))
...
```

``` js
...
.use(purifyCSS({
  content: ['*.html', '*.js'],
  css: ['file1.css', 'file2.css'],
  output: 'styles-purified.css',
}))
...
```