### PR TITLE
Added "removeOriginal" option which removes original CSS files after purifying.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,12 @@ const minimatch = require('minimatch');
 const purifyCSS = require('purify-css');
 
 const plugin = (options) => {
-  const {content, css, output} = options;
+  const {content, css, output, removeOriginal} = options;
   // Delete options that conflict with running in Metalsmith
   delete options.content;
   delete options.css;
   delete options.output;
+  delete options.removeOriginal;
 
   return function(files, metalsmith, done) {
     const fileNames = Object.keys(files);
@@ -28,7 +29,8 @@ const plugin = (options) => {
 
     // Stringify matched HTML & CSS file contents
     const structure = concatContents(filterFiles(content));
-    const styles = concatContents(filterFiles(css));
+    const cssFiles = filterFiles(css);
+    const styles = concatContents(cssFiles);
 
     // Pass code and CSS to Purify
     purifyCSS(structure, styles, options, (results) => {
@@ -36,6 +38,12 @@ const plugin = (options) => {
         contents: new Buffer(results)
       }
     });
+
+    if (removeOriginal) {
+      for (i = 0; i < cssFiles.length; ++i) {
+        delete files[cssFiles[i]];
+      }
+    }
 
     done();
   }


### PR DESCRIPTION
This extra option ensures that original CSS files are not copied to the build folder after purification (if so desired).